### PR TITLE
Make cURL headers as static parameter for custom http header options

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -53,6 +53,9 @@ class SoapClientAsync extends SoapClient
     /** @var bool exit after print soap */
     public static $exitAfterPrint = false;
 
+    /** @var array header options */
+    public static $curlHeaders = [];
+
     /**
      * @var array
      */
@@ -128,14 +131,19 @@ class SoapClientAsync extends SoapClient
 
             return $data;
         }
+
         /** @var $headers array of headers to be sent with request */
-        $headers = [
-            'Content-type: text/xml',
-            'charset=utf-8',
-            "Accept: text/xml",
-            'SOAPAction: "' . $action . '"',
-            "Content-length: " . strlen($request),
-        ];
+        $headers  = &static::$curlHeaders;
+        if (empty($headers)) {
+            $headers = [
+                'Content-type: text/xml',
+                'charset=utf-8',
+                "Accept: text/xml",
+                'SOAPAction: "' . $action . '"',
+                "Content-length: " . strlen($request),
+            ];
+        }
+
         // ssl connection sharing
         if (empty(static::$sharedCurlData[$location])) {
             $shOpt = curl_share_init();


### PR DESCRIPTION
First, thank you very much for the lib, it's exactly what I'm searching for, and I can tell that it still working great with Php 7.2.4.

Well, I'd like to make this contribution making the cURL headers as static parameter for custom http header options, so you don't need to mess with the lib and can do something like that on app:

```
$client::$curlHeaders = [
    "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
    "Connection: Keep-Alive",
    "Accept-Encoding: gzip, deflate",
    "Content-Type: text/xml; charset=UTF-8",
];
```
